### PR TITLE
Metrics exporter - add /metrics suffix

### DIFF
--- a/datadog/conf.yaml
+++ b/datadog/conf.yaml
@@ -1,5 +1,5 @@
 instances:
-  - openmetrics_endpoint: "https://api.scout.docker.com/v1/exporter/org/<ORG>"
+  - openmetrics_endpoint: "https://api.scout.docker.com/v1/exporter/org/<ORG>/metrics"
     namespace: "scout-metrics-exporter"
     metrics:
       - scout_*

--- a/prometheus/prometheus/prometheus.yaml
+++ b/prometheus/prometheus/prometheus.yaml
@@ -3,7 +3,7 @@ global:
   scrape_timeout: 40s
 scrape_configs:
   - job_name: <ORG>
-    metrics_path: /v1/exporter/org/<ORG>
+    metrics_path: /v1/exporter/org/<ORG>/metrics
     scheme: https
     static_configs:
       - targets:


### PR DESCRIPTION
This PR adds the /metrics suffix to follow the convention of Prometheus exporters.